### PR TITLE
Add deployments delete command

### DIFF
--- a/cloudlaunch_cli/main.py
+++ b/cloudlaunch_cli/main.py
@@ -115,6 +115,14 @@ def create_deployment(name, application, cloud, target_id, application_version,
 
 
 @click.command()
+@click.argument('id')
+@click.argument('cloud')
+def delete_deployment(id, cloud):
+    cloudlaunch_client = create_api_client(cloud)
+    cloudlaunch_client.deployments.delete(id)
+
+
+@click.command()
 @click.option('--archived', is_flag=True,
               help='Show only archived deployments')
 def list_deployments(archived):
@@ -319,6 +327,7 @@ config.add_command(show_config, name='show')
 
 deployments.add_command(create_deployment, name='create')
 deployments.add_command(list_deployments, name='list')
+deployments.add_command(delete_deployment, name='delete')
 
 applications.add_command(create_application, name='create')
 applications.add_command(list_applications, name='list')


### PR DESCRIPTION
Add a `delete` command so deployments can be deleted from the CLI.

There is an issue as `cloudlaunch_client.deployments.delete(id)` does not function the same as deleting a deployment in the cloudlaunch UI. In particular all traces of the deployment are lost and it will no longer appear in listings of deployments.